### PR TITLE
prevent empty element xr:Item_price_base_quantity

### DIFF
--- a/src/xsl/cii-xr.xsl
+++ b/src/xsl/cii-xr.xsl
@@ -1942,23 +1942,25 @@
                               select="./ram:GrossPriceProductTradePrice/ram:AppliedTradeAllowanceCharge/ram:ActualAmount"/>
          <xsl:apply-templates mode="BT-148"
                               select="./ram:GrossPriceProductTradePrice/ram:ChargeAmount"/>
-         <xr:Item_price_base_quantity>
-            <xsl:attribute name="xr:id" select="'BT-149'"/>
-            <xsl:attribute name="xr:src" select="'/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:NetPriceProductTradePrice/ram:ChargeAmount|/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:GrossPriceProductTradePrice/ram:AppliedTradeAllowanceCharge/ram:ActualAmount'"/>
-            <xsl:choose>
-               <xsl:when test="./ram:NetPriceProductTradePrice/ram:BasisQuantity != ./ram:GrossPriceProductTradePrice/ram:BasisQuantity">
-                  <xsl:apply-templates mode="BT-149"
-                     select="./ram:NetPriceProductTradePrice/ram:BasisQuantity"/>
-                  <xsl:value-of select="';'"/>
-                  <xsl:apply-templates mode="BT-149"
-                     select="./ram:GrossPriceProductTradePrice/ram:BasisQuantity"/>
-               </xsl:when>
-               <xsl:otherwise>
-                  <xsl:apply-templates mode="BT-149"
-                     select="./ram:NetPriceProductTradePrice/ram:BasisQuantity"/>
-               </xsl:otherwise>
-            </xsl:choose>
-         </xr:Item_price_base_quantity>         
+         <xsl:if test="count(./ram:NetPriceProductTradePrice/ram:BasisQuantity) > 0">
+            <xr:Item_price_base_quantity>
+               <xsl:attribute name="xr:id" select="'BT-149'"/>
+               <xsl:attribute name="xr:src" select="'/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:NetPriceProductTradePrice/ram:ChargeAmount|/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:GrossPriceProductTradePrice/ram:AppliedTradeAllowanceCharge/ram:ActualAmount'"/>
+               <xsl:choose>
+                  <xsl:when test="./ram:NetPriceProductTradePrice/ram:BasisQuantity != ./ram:GrossPriceProductTradePrice/ram:BasisQuantity">
+                     <xsl:apply-templates mode="BT-149"
+                        select="./ram:NetPriceProductTradePrice/ram:BasisQuantity"/>
+                     <xsl:value-of select="';'"/>
+                     <xsl:apply-templates mode="BT-149"
+                        select="./ram:GrossPriceProductTradePrice/ram:BasisQuantity"/>
+                  </xsl:when>
+                  <xsl:otherwise>
+                     <xsl:apply-templates mode="BT-149"
+                        select="./ram:NetPriceProductTradePrice/ram:BasisQuantity"/>
+                  </xsl:otherwise>
+               </xsl:choose>
+            </xr:Item_price_base_quantity>
+         </xsl:if>
          <xsl:apply-templates mode="BT-150"
                               select="./ram:GrossPriceProductTradePrice/ram:BasisQuantity/@unitCode"/>
       </xsl:variable>


### PR DESCRIPTION
BT-149 "Item price base quantity" is an optional property, but in the cii-xr.xsl stylesheet, it always gets created